### PR TITLE
Fixed Bug in Accordion Collapse in 'Frequently Client Says' Section.

### DIFF
--- a/bike-palace/index.html
+++ b/bike-palace/index.html
@@ -892,15 +892,15 @@
                             </div>
                         </div>
                         <div class="accordion-item my-3">
-                            <h2 class="accordion-header" id="panelsStayOpen-headingThree">
+                            <h2 class="accordion-header" id="panelsStayOpen-headingFour">
                                 <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                                    data-bs-target="#panelsStayOpen-collapseThree" aria-expanded="false"
-                                    aria-controls="panelsStayOpen-collapseThree">
+                                    data-bs-target="#panelsStayOpen-collapseFour" aria-expanded="false"
+                                    aria-controls="panelsStayOpen-collapseFour">
                                     What rules should I follow when riding my bike?
                                 </button>
                             </h2>
-                            <div id="panelsStayOpen-collapseThree" class="accordion-collapse collapse"
-                                aria-labelledby="panelsStayOpen-headingThree">
+                            <div id="panelsStayOpen-collapseFour" class="accordion-collapse collapse"
+                                aria-labelledby="panelsStayOpen-headingFour">
                                 <div class="accordion-body">
                                     <strong>This is the third item's accordion body.</strong> It is hidden by default,
                                     until the collapse plugin adds the appropriate classes that we use to style each


### PR DESCRIPTION
I found and fixed a bug in the "Frequently Client Says" section of the `index.html` file. The issue was that clicking on the third collapse would automatically open the fourth collapse. This pull request corrects that behavior.
